### PR TITLE
feat: enable decoupled completion of tasks

### DIFF
--- a/extension/src/main/kotlin/adapter/AbstractRuntimeServiceAdapter.kt
+++ b/extension/src/main/kotlin/adapter/AbstractRuntimeServiceAdapter.kt
@@ -10,9 +10,9 @@
  *  ownership. Camunda licenses this file to you under the Apache License,
  *  Version 2.0; you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -134,6 +134,18 @@ abstract class AbstractRuntimeServiceAdapter : RuntimeService {
   }
 
   override fun setVariables(executionId: String, variables: MutableMap<String, out Any>) {
+    implementedBy(RemoteRuntimeService::class)
+  }
+
+  open fun completeTask(externalTaskId: String, taskWorkerId: String) {
+    implementedBy(RemoteRuntimeService::class)
+  }
+
+  open fun completeTask(externalTaskId: String, taskWorkerId: String, updateVariables: MutableMap<String, out Any>) {
+    implementedBy(RemoteRuntimeService::class)
+  }
+
+  open fun completeTask(externalTaskId: String, taskWorkerId: String, updateVariables: MutableMap<String, out Any>, updateLocalVariables: MutableMap<String, out Any>) {
     implementedBy(RemoteRuntimeService::class)
   }
 

--- a/extension/src/main/kotlin/client/RuntimeServiceClient.kt
+++ b/extension/src/main/kotlin/client/RuntimeServiceClient.kt
@@ -10,9 +10,9 @@
  *  ownership. Camunda licenses this file to you under the Apache License,
  *  Version 2.0; you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@
 
 package org.camunda.bpm.extension.rest.client
 
+import impl.CompleteTaskDto
 import org.camunda.bpm.engine.rest.dto.PatchVariablesDto
 import org.camunda.bpm.engine.rest.dto.SignalDto
 import org.camunda.bpm.engine.rest.dto.VariableValueDto
@@ -42,6 +43,13 @@ import org.springframework.web.bind.annotation.RequestParam
  */
 @FeignClient(name = "remoteRuntimeService", url = "\${feign.client.config.remoteRuntimeService.url}")
 interface RuntimeServiceClient {
+
+  /**
+   * Completes external task
+   * @see https://docs.camunda.org/manual/latest/reference/rest/external-task/post-complete
+   */
+  @RequestMapping(method = [RequestMethod.POST], value = ["/external-task/{id}/complete"], consumes = ["application/json"])
+  fun completeTask(@PathVariable("id") id: String, completeTask: CompleteTaskDto)
 
   /**
    * Correlates message.

--- a/extension/src/main/kotlin/impl/CompleteTaskDto.kt
+++ b/extension/src/main/kotlin/impl/CompleteTaskDto.kt
@@ -1,0 +1,9 @@
+package impl
+
+import org.camunda.bpm.engine.rest.dto.VariableValueDto
+
+class CompleteTaskDto {
+  var workerId: String? = null
+  var variables: Map<String, VariableValueDto>? = null
+  var localVariables: Map<String, VariableValueDto>? = null
+}

--- a/extension/src/main/kotlin/impl/RemoteRuntimeService.kt
+++ b/extension/src/main/kotlin/impl/RemoteRuntimeService.kt
@@ -23,6 +23,7 @@
 package org.camunda.bpm.extension.rest.impl
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import impl.CompleteTaskDto
 import org.camunda.bpm.engine.ProcessEngine
 import org.camunda.bpm.engine.rest.dto.PatchVariablesDto
 import org.camunda.bpm.engine.rest.dto.runtime.ExecutionTriggerDto
@@ -359,6 +360,22 @@ class RemoteRuntimeService(
   override fun setVariables(executionId: String, variables: MutableMap<String, out Any>) {
     return runtimeServiceClient.changeVariables(executionId, PatchVariablesDto().apply {
       modifications = valueMapper.mapValues(variables)
+    })
+  }
+
+  override fun completeTask(externalTaskId: String, taskWorkerId: String ) {
+    this.completeTask(externalTaskId, taskWorkerId, mutableMapOf())
+  }
+
+  override fun completeTask(externalTaskId: String, taskWorkerId: String, updateVariables: MutableMap<String, out Any> ) {
+    this.completeTask(externalTaskId, taskWorkerId, updateVariables, mutableMapOf())
+  }
+
+  override fun completeTask(externalTaskId: String, taskWorkerId: String, updateVariables: MutableMap<String, out Any>, updateLocalVariables: MutableMap<String, out Any> ) {
+    return runtimeServiceClient.completeTask(externalTaskId, CompleteTaskDto().apply {
+      variables = valueMapper.mapValues(updateVariables)
+      localVariables = valueMapper.mapValues(updateLocalVariables)
+      workerId = taskWorkerId
     })
   }
 }


### PR DESCRIPTION
Enable the decoupled task worker pattern that all the cool kids are doing these days (see: https://github.com/creditsenseau/zeebe-client-node-js/pull/112). 

Used it in a customer POC this week. The official JS client supports it out of the box (`Client.taskService.complete`).